### PR TITLE
Display components dynamically

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,20 +1,65 @@
+import { Type } from "@angular/core";
+import { ButtonComponent } from "./components/ui/button/button.component";
+import { LinkComponent } from "./components/ui/link/link.component";
+import { IconComponent } from "./components/ui/icon/icon.component";
+
+export type ComponentStructure = {
+    id: number;
+    label: string;
+    title: string;
+    description: string;
+    url: string;
+    component: Type<unknown>;
+};
+
+const components: ComponentStructure[] = [
+    {        
+        id: 1,            
+        label: 'Buttons',
+        title: 'Button',
+        description: 'Button Control',
+        url: 'https://taiga-ui.dev/components/button',
+        component: ButtonComponent        
+    },
+    {        
+        id: 2,            
+        label: 'Links',
+        title: 'Link',
+        description: 'Link Control',
+        url: 'https://taiga-ui.dev/components/link',
+        component: LinkComponent
+    },
+    {        
+        id: 3,            
+        label: 'Icons',
+        title: 'Icon',
+        description: 'Icon Control',
+        url: 'https://taiga-ui.dev/components/icon',
+        component: IconComponent
+    },
+    {        
+        id: 4,            
+        label: 'Icons',
+        title: 'Test Component 1',
+        description: 'Icon Control',
+        url: 'https://taiga-ui.dev/components/icon',
+        component: IconComponent
+    },
+    {        
+        id: 5,            
+        label: 'Icons',
+        title: 'Test Component 2',
+        description: 'Icon Control',
+        url: 'https://taiga-ui.dev/components/icon',
+        component: IconComponent
+    }
+]
+
 export const AppConfig = {
+    components,
     componentTypeFilter: {
         label: 'Component type',
         placeHolder: 'Component type',
-        items: [
-            {
-                id: 1,
-                value: 'Text inputs'
-            },
-            {
-                id: 2,
-                value: 'Buttons'
-            },
-            {
-              id: 3,
-              value: 'Legacy'
-            }
-        ]
-    }    
+        items: components.map(({id, label}) => ({id, label}))
+    },    
 };

--- a/src/app/components/ui/button/button.component.html
+++ b/src/app/components/ui/button/button.component.html
@@ -1,51 +1,6 @@
-<app-element-container title="Button">
-    <app-element-card title="Button" description="Button Control"
-                      url="https://taiga-ui.dev/components/button">
-        <button
-                size="l"
-                tuiButton
-                type="button"
-        >
-            Large
-        </button>
-    </app-element-card>
-    <app-element-card title="Button Close" description="Close Button"
-                      url="https://taiga-ui.dev/components/button-close">
-        <button
-                tuiButtonClose
-                tuiIconButton
-                type="button"
-        >
-            Close
-        </button>
-    </app-element-card>
-    <app-element-card title="Button Group" description="Button Groups"
-                      url="https://taiga-ui.dev/components/button-group">
-        <div
-                tuiButtonGroup
-                tuiSurface="elevated"
-        >
-            <button type="button">
-                <tui-icon icon="@tui.circle-plus"/>
-                Create a payment
-            </button>
-
-            <button type="button">
-                <tui-icon
-                        badge=""
-                        icon="@tui.circle-plus"
-                />
-                Pay the bill
-            </button>
-
-            <button type="button">
-                <tui-icon
-                        badge="@tui.lock"
-                        icon="@tui.circle-plus"
-                        class="custom"
-                />
-                Remove from favorites
-            </button>
-        </div>
-    </app-element-card>
-</app-element-container>
+<button
+    size="l"
+    tuiButton
+    type="button">
+    Large
+</button>

--- a/src/app/components/ui/icon/icon.component.html
+++ b/src/app/components/ui/icon/icon.component.html
@@ -1,0 +1,9 @@
+<tui-icon
+icon="@tui.heart"
+[style.color]="'var(--tui-background-accent-1)'"
+/>
+
+<img
+alt=""
+[src]="'@tui.heart' | tuiIcon"
+/>

--- a/src/app/components/ui/icon/icon.component.spec.ts
+++ b/src/app/components/ui/icon/icon.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LinkComponent } from './icon.component';
+
+describe('LinkComponent', () => {
+  let component: LinkComponent;
+  let fixture: ComponentFixture<LinkComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LinkComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(LinkComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/ui/icon/icon.component.ts
+++ b/src/app/components/ui/icon/icon.component.ts
@@ -1,0 +1,12 @@
+import {Component} from '@angular/core';
+import { TuiIcon, TuiIconPipe } from '@taiga-ui/core';
+
+@Component({
+    selector: 'app-icon',
+    standalone: true,
+    imports: [TuiIcon, TuiIconPipe],
+    templateUrl: './icon.component.html',
+    styleUrl: './icon.component.scss'
+})
+export class IconComponent {
+}

--- a/src/app/components/ui/link/link.component.html
+++ b/src/app/components/ui/link/link.component.html
@@ -1,0 +1,5 @@
+<a
+tuiLink
+>
+Link
+</a>

--- a/src/app/components/ui/link/link.component.spec.ts
+++ b/src/app/components/ui/link/link.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LinkComponent } from './link.component';
+
+describe('LinkComponent', () => {
+  let component: LinkComponent;
+  let fixture: ComponentFixture<LinkComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LinkComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(LinkComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/ui/link/link.component.ts
+++ b/src/app/components/ui/link/link.component.ts
@@ -1,0 +1,13 @@
+import {Component} from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { TuiLink } from '@taiga-ui/core';
+
+@Component({
+    selector: 'app-link',
+    standalone: true,
+    imports: [RouterLink, TuiLink],
+    templateUrl: './link.component.html',
+    styleUrl: './link.component.scss'
+})
+export class LinkComponent {
+}

--- a/src/app/components/ui/taiga/combo-box/combo-box.component.ts
+++ b/src/app/components/ui/taiga/combo-box/combo-box.component.ts
@@ -1,5 +1,5 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, computed, inject, input, OnInit, signal } from '@angular/core';
-import {FormControl, FormGroup, FormGroupDirective, ReactiveFormsModule} from '@angular/forms';
+import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
+import { FormGroupDirective, ReactiveFormsModule} from '@angular/forms';
 import {TuiDataList} from '@taiga-ui/core';
 import {TuiComboBoxModule, TuiTextfieldControllerModule} from '@taiga-ui/legacy';
 import {
@@ -36,7 +36,7 @@ export class ComboBoxComponent {
 
   @tuiPure
   itemValue(id: number | string) {    
-    return this.config().items.find((item) => item.id === id)?.value || '';
+    return this.config().items.find((item) => item.id === id)?.label || '';
   }
   
 }

--- a/src/app/components/ui/taiga/combo-box/combo-box.interface.ts
+++ b/src/app/components/ui/taiga/combo-box/combo-box.interface.ts
@@ -6,5 +6,5 @@ export type ComboBox = {
 
 export type ComboBoxItem = {
     id: number | string;
-    value: string;
+    label: string;
 }

--- a/src/app/components/ui/toolbar/toolbar.component.html
+++ b/src/app/components/ui/toolbar/toolbar.component.html
@@ -1,4 +1,4 @@
 <div [formGroup]="searchForm">
-    <app-combo-box [config]="dashboardService.getToolbarFilterByComponentTypeConfig()" [fControlName]="'componentType'"></app-combo-box>
+    <app-combo-box [config]="dashboardService.getToolbarFilterByComponentTypeConfig()" [fControlName]="'componentId'"></app-combo-box>
     <app-search [fControlName]="'searchInput'"></app-search>
 </div>

--- a/src/app/components/ui/toolbar/toolbar.component.ts
+++ b/src/app/components/ui/toolbar/toolbar.component.ts
@@ -1,6 +1,6 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, inject } from "@angular/core";
+import { AfterViewInit, ChangeDetectionStrategy, Component, inject, output } from "@angular/core";
 import { ComboBoxComponent } from "../taiga/combo-box/combo-box.component";
-import { DashboardService } from "../../../services/dashboard.service";
+import { DashboardService, SearchFilter } from "../../../services/dashboard.service";
 import { FormBuilder, FormControl, ReactiveFormsModule } from "@angular/forms";
 import { SearchComponent } from "../taiga/search/search.component";
 
@@ -14,13 +14,18 @@ import { SearchComponent } from "../taiga/search/search.component";
   export class ToolbarComponent implements AfterViewInit {
     protected readonly dashboardService = inject(DashboardService);
     readonly #formBuilder = inject(FormBuilder);
+    onChange = output<SearchFilter>();
 
     searchForm = this.#formBuilder.group({
-        componentType: new FormControl(),
-        searchInput: new FormControl()
+        componentId: new FormControl<number>(-1),
+        searchInput: new FormControl<string>('')
     });
 
     ngAfterViewInit(): void {
-        this.searchForm.valueChanges.subscribe(x => console.log(x))
+      this.searchForm.valueChanges.subscribe(value => {                         
+        this.onChange.emit({
+          id: value.componentId,
+          query: value.searchInput} as SearchFilter);
+      });
     }
   }

--- a/src/app/controls/element-card/element-card.component.scss
+++ b/src/app/controls/element-card/element-card.component.scss
@@ -1,6 +1,6 @@
 .card {
   background-color: #f6f6f6;
-  width: 35rem;
+  width: 100%;
   border: #e0e0e0 1px solid;
   border-radius: 8px;
   .content{

--- a/src/app/controls/element-container/element-container.component.html
+++ b/src/app/controls/element-container/element-container.component.html
@@ -1,6 +1,6 @@
-<div style="flex-direction: column;">
+<div class="container">
     <h2>{{ title() }}</h2>
-    <div class="content" [ngClass]="isMobile? 'mobile-content': ''">
+    <div>
         <ng-content></ng-content>
     </div>
 </div>

--- a/src/app/controls/element-container/element-container.component.scss
+++ b/src/app/controls/element-container/element-container.component.scss
@@ -1,13 +1,3 @@
-.content{
-  display: flex;
-  flex-direction: row;
-  gap: 2rem 2rem;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-
-}
-
-.mobile-content{
-  justify-content: center;
+.container {
+    padding: 10px;
 }

--- a/src/app/controls/element-container/element-container.component.ts
+++ b/src/app/controls/element-container/element-container.component.ts
@@ -1,5 +1,4 @@
-import {Component, inject, input} from '@angular/core';
-import {TUI_IS_MOBILE} from "@taiga-ui/cdk";
+import {Component, input} from '@angular/core';
 import {NgClass} from "@angular/common";
 
 @Component({
@@ -12,7 +11,5 @@ import {NgClass} from "@angular/common";
   styleUrl: './element-container.component.scss'
 })
 export class ElementContainerComponent {
-  title= input<string>('');
-
-  protected readonly isMobile = inject(TUI_IS_MOBILE);
+  title= input<string>('');  
 }

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -1,4 +1,15 @@
 <div class="p-16">
-    <app-toolbar></app-toolbar>
-    <app-button></app-button>
+    <app-toolbar (onChange)="dashboardService.onSearchChange($event)"></app-toolbar>
+
+    <div class="main-content-wrapper">
+        @for (item of dashboardService.state(); track $index) {   
+            <div class="column">
+                <app-element-container [title]="item.title">
+                    <app-element-card [title]="item.title" [description]="item.description" [url]="item.url">
+                        <ng-container *ngComponentOutlet="item.component"></ng-container>
+                    </app-element-card>
+                </app-element-container>
+            </div>
+        }
+    </div>
 </div>

--- a/src/app/dashboard/dashboard.component.scss
+++ b/src/app/dashboard/dashboard.component.scss
@@ -1,0 +1,21 @@
+.main-content-wrapper {
+    display: flex;
+    flex-wrap: wrap;    
+    margin-left: -10px;
+    margin-right: -10px;
+
+    .column {
+        flex: 0 0 33.333333%;                
+        max-width: 33.333333%;             
+    }
+}
+
+@media screen and (max-width: 992px) {
+    .main-content-wrapper {
+        flex-direction: column;
+
+        .column {
+            max-width: 100%;
+        }
+    }
+}

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -1,6 +1,10 @@
-import {ChangeDetectionStrategy, Component} from "@angular/core";
+import {ChangeDetectionStrategy, Component, inject} from "@angular/core";
 import {ToolbarComponent} from "../components/ui/toolbar/toolbar.component";
 import {ButtonComponent} from "../components/ui/button/button.component";
+import { DashboardService } from "../services/dashboard.service";
+import { NgComponentOutlet } from "@angular/common";
+import { ElementContainerComponent } from "../controls/element-container/element-container.component";
+import { ElementCardComponent } from "../controls/element-card/element-card.component";
 
 @Component({
     selector: 'app-dashboard',
@@ -8,7 +12,9 @@ import {ButtonComponent} from "../components/ui/button/button.component";
     templateUrl: './dashboard.component.html',
     styleUrl: 'dashboard.component.scss',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [ToolbarComponent, ButtonComponent],
+    imports: [ToolbarComponent, ButtonComponent, NgComponentOutlet, ElementContainerComponent, ElementCardComponent],
 })
 export class DashboardComponent {
+    
+    protected readonly dashboardService = inject(DashboardService);     
 }

--- a/src/app/services/dashboard.service.ts
+++ b/src/app/services/dashboard.service.ts
@@ -1,4 +1,4 @@
-import { inject, Injectable, InjectionToken } from "@angular/core";
+import { computed, inject, Injectable, InjectionToken, signal } from "@angular/core";
 import { ComboBox } from "../components/ui/taiga/combo-box/combo-box.interface";
 import { AppConfig } from "../app.config";
 
@@ -9,15 +9,35 @@ export const COMPONENT_TYPE_FILTER_CONFIG = new InjectionToken(
   factory: () => AppConfig.componentTypeFilter
 });
 
+export type SearchFilter = {
+  id: number;
+  query: string | null;
+}
+
 @Injectable({
     providedIn: 'root',
   })
   export class DashboardService {
 
-    componentTypeFilterConfig = inject(COMPONENT_TYPE_FILTER_CONFIG);
+    readonly #componentTypeFilterConfig = inject(COMPONENT_TYPE_FILTER_CONFIG);
+    readonly #components = AppConfig.components;
+    #search = signal<SearchFilter>({
+      id: -1,
+      query: null
+    });
+
+    state = computed(() => { 
+      const selectedId = this.#search().id;              
+      
+      return selectedId === -1 ? this.#components : this.#components.filter(c => c.id === selectedId);        
+    });
 
     getToolbarFilterByComponentTypeConfig(): ComboBox {
-      return this.componentTypeFilterConfig;
+      return this.#componentTypeFilterConfig;
     }
 
-  }
+    onSearchChange(data: SearchFilter) {
+      this.#search.set(data);
+    }
+
+}


### PR DESCRIPTION
Dynamic component rendering has been added.
Each new Taiga-UI component is wrapped in a `app-element-container` component and rendered inside the ng-container tag:
```
<div class="main-content-wrapper">
        @for (item of dashboardService.state(); track $index) {   
            <div class="column">
                <app-element-container [title]="item.title">
                    <app-element-card [title]="item.title" [description]="item.description" [url]="item.url">
                        <ng-container *ngComponentOutlet="item.component"></ng-container>
                    </app-element-card>
                </app-element-container>
            </div>
        }
    </div>
```

The only thing that we have to do now is to create each new UI component and add it to app configs components array as follows:

```
{        
        id: ...,            
        label: 'New label', //label is used for the toolbar dropdown
        title: 'Some title',
        description: 'Some description',
        url: 'Some url',
        component: TheNewUiComponent        
    },
```
This approach is more flexible and works out of the box for every component added without adding extra markup component wrappers. In addition, the components are represented in a 3 column format on screens larger than 992px. On screens <992px, each component takes up the whole available width. 
At the moment, only the dropdown filtering is functional; the search filtering will be added as a separate improvement.
Feel free to add any suggestions or improvements.