### PR TITLE
Review Scroll Optimizations

### DIFF
--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -14,6 +14,7 @@
         <div
           class="column"
           [observeVisibility]="$index"
+          [totalItems]="dashboardService.componentItems().length"
           (visible)="dashboardService.onNextPage()"
         >
           <ng-container

--- a/src/app/dashboard/observer-visibility.directive.ts
+++ b/src/app/dashboard/observer-visibility.directive.ts
@@ -88,7 +88,6 @@ export class ObserveVisibilityDirective {
         const isStillVisible = await this.isVisible(target);
 
         if (isStillVisible && this.isBoundaryItem()) {
-          console.log('boundary item');
           this.visible.emit(target);
           observer.unobserve(target);
         }


### PR DESCRIPTION
Couple of things noted here:

- We need to decouple observer visibility directive from any external services like `DashboardService`. All required state should be provided as required input properties like `totalItems`.
- Use of effect should be avoided as much as possible and must be the last alternative when all possible solutions cannot fit.
- I reverted back the use of subject since we need to provide the debounce time capability for the scrolling.